### PR TITLE
Cleanup of example files

### DIFF
--- a/examples/gcp/active_directory/provider.tf
+++ b/examples/gcp/active_directory/provider.tf
@@ -1,6 +1,6 @@
 # Specify the provider and access details
 provider "netapp-gcp" {
-  project         = "${var.gcp_project}"
-  service_account = "${var.gcp_service_account}"
+  project         = var.gcp_project_number
+  service_account = var.gcp_service_account
 }
 

--- a/examples/gcp/active_directory/terraform.tfvars.example
+++ b/examples/gcp/active_directory/terraform.tfvars.example
@@ -1,8 +1,10 @@
 # edit the `terraform.tfvars.example` file, populating the fields with the
-relevant values, and then rename it to `terraform.tfvars`.
+# relevant values, and then rename it to `terraform.tfvars`.
 
+# GCP project number
+gcp_project_number = "********"
 
-gcp_project = "********"
-
+# Absolut path to keyfile (.json) for service account with roles/netappcloudvolumes.admin.
+# See https://cloud.google.com/solutions/partners/netapp-cloud-volumes/api?hl=en_US
 gcp_service_account = "/Users/********/Downloads/cvs-terraform-dev-********.json"
 

--- a/examples/gcp/active_directory/variables.tf
+++ b/examples/gcp/active_directory/variables.tf
@@ -1,7 +1,7 @@
 variable "gcp_project" {
-  type = "string"
+  type = string
 }
 
 variable "gcp_service_account" {
-  type = "string"
+  type = string
 }

--- a/examples/gcp/provider.tf
+++ b/examples/gcp/provider.tf
@@ -1,6 +1,6 @@
 # Specify the provider and access details
 provider "netapp-gcp" {
-  project         = "${var.gcp_project}"
-  service_account = "${var.gcp_service_account}"
+  project         = var.gcp_project_number
+  service_account = var.gcp_service_account
 }
 

--- a/examples/gcp/resources.tf
+++ b/examples/gcp/resources.tf
@@ -4,7 +4,7 @@ resource "netapp-gcp_volume" "gcp-volume" {
   provider = netapp-gcp
   name = "deleteme_asapGO"
   region = "us-west2"
-  protocol_types = ["NFSv3","SMB"]
+  protocol_types = ["NFSv3"]
   network = "cvs-terraform-vpc"
   size = 1024
   service_level = "medium"
@@ -14,7 +14,7 @@ resource "netapp-gcp_snapshot" "gcp-snapshot" {
   provider = netapp-gcp
   name = "deleteme_snapshot_asapGo"
   region = "us-west2"
-  volume_name =  "testing"
-  creation_token = "pensive-sleepy-easley"
+  volume_name =  "deleteme_asapGO"
+  # creation_token = "pensive-sleepy-easley"
   depends_on = [netapp-gcp_volume.gcp-volume]
 }

--- a/examples/gcp/terraform.tfvars.example
+++ b/examples/gcp/terraform.tfvars.example
@@ -1,8 +1,10 @@
 # edit the `terraform.tfvars.example` file, populating the fields with the
-relevant values, and then rename it to `terraform.tfvars`.
+# relevant values, and then rename it to `terraform.tfvars`.
 
+# GCP project number
+gcp_project_number = "********"
 
-gcp_project = 
-
-gcp_service_account = 
+# Absolut path to keyfile (.json) for service account with roles/netappcloudvolumes.admin.
+# See https://cloud.google.com/solutions/partners/netapp-cloud-volumes/api?hl=en_US
+gcp_service_account = "/Users/********/Downloads/cvs-terraform-dev-********.json"
 

--- a/examples/gcp/variables.tf
+++ b/examples/gcp/variables.tf
@@ -1,7 +1,7 @@
 variable "gcp_project" {
-  type = "string"
+  type = string
 }
 
 variable "gcp_service_account" {
-  type = "string"
+  type = string
 }

--- a/examples/gcp/volume/provider.tf
+++ b/examples/gcp/volume/provider.tf
@@ -1,6 +1,6 @@
 # Specify the provider and access details
 provider "netapp-gcp" {
-  project         = "${var.gcp_project}"
-  service_account = "${var.gcp_service_account}"
+  project         = var.gcp_project_number
+  service_account = var.gcp_service_account
 }
 

--- a/examples/gcp/volume/terraform.tfvars.example
+++ b/examples/gcp/volume/terraform.tfvars.example
@@ -1,8 +1,10 @@
 # edit the `terraform.tfvars.example` file, populating the fields with the
-relevant values, and then rename it to `terraform.tfvars`.
+# relevant values, and then rename it to `terraform.tfvars`.
 
+# GCP project number
+gcp_project_number = "********"
 
-gcp_project = "********"
-
-gcp_service_account = ""
+# Absolut path to keyfile (.json) for service account with roles/netappcloudvolumes.admin.
+# See https://cloud.google.com/solutions/partners/netapp-cloud-volumes/api?hl=en_US
+gcp_service_account = "/Users/********/Downloads/cvs-terraform-dev-********.json"
 

--- a/examples/gcp/volume/variables.tf
+++ b/examples/gcp/volume/variables.tf
@@ -1,7 +1,7 @@
 variable "gcp_project" {
-  type = "string"
+  type = string
 }
 
 variable "gcp_service_account" {
-  type = "string"
+  type = string
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -22,8 +22,8 @@ and therefore may undergo significant changes as the community improves it.
 ```
 # Configure the NetApp_GCP Provider
 provider "netapp_gcp" {
-  project         = "${var.gcp_project}"
-  service_account = "${var.gcp_service_account}"
+  project         = var.gcp_project_number
+  service_account = var.gcp_service_account
 }
 
 # Create a volume tied to an account
@@ -68,10 +68,10 @@ resource "netapp-gcp_volume" "gcp-volume" {
 
 # Create a snapshot tied to an volume
 resource "netapp-gcp_snapshot" "gcp-snapshot" {
-  name = "main-snapshot"
+  name = "deleteme_asapGO_jusitin-snapshot"
   region = "us-west2"
-  volume_name =  "main-volume"
-  creation_token = "unique-token-number"
+  volume_name =  "deleteme_asapGO_jusitin"
+  # creation_token = "unique-token-number"
 }
 
 # Create an Active Directory
@@ -90,7 +90,7 @@ resource "netapp-gcp_active_directory" "gcp-active-directory" {
 
 The following arguments are used to configure the NetApp_GCP Provider:
 
-* `project` - (Required) This is the project ID for NetApp_GCP API operations.
+* `project` - (Required) This is the project number for NetApp_GCP API operations.
 * `service_account` - (Required) This is the path of service_account for NetApp_GCP API operations.
 
 ## Required Privileges


### PR DESCRIPTION
Improvements of the example files to make starting the provider easier.

 - Changed syntax to Terraform >= v0.12 format to eliminate warnings

 - Clarification on GCP project number vs project ID

 - Clarification on how the specify service account file

 - Improve snapshot create example to use volume just created

 - Update website doc to clarify GCP project number vs project ID