### PR TITLE
Add exported attributes / outputs

### DIFF
--- a/examples/gcp/volume/output.tf
+++ b/examples/gcp/volume/output.tf
@@ -1,0 +1,27 @@
+# returns IP/hostname of CVS export, e.g. 10.194.0.4
+output "server" {
+  value       = netapp-gcp_volume.gcp-volume.mountpoints[0].server
+  description = "The server address of the cloud volume."
+}
+# returns export path of CVS export, e.g. /ecstatic-dazzling-chandrasekhar
+output "export" {
+  value       = netapp-gcp_volume.gcp-volume.mountpoints[0].export
+  description = "The export path of the cloud volume."
+}
+
+# returns full export path, e.g 10.194.0.4:/ecstatic-dazzling-chandrasekhar
+output "exportfull" {
+  value       = netapp-gcp_volume.gcp-volume.mountpoints[0].exportfull
+  description = "The full export path of the cloud volume."
+}
+
+output "protocoltype"  {
+  value       = netapp-gcp_volume.gcp-volume.mountpoints[0].protocoltype
+  description = "The protocol type of the export."
+}
+
+# If volume got multiple mount points (e.g. NFSv3 and NFSv4), use below method to get data for specific protocol
+# output "exportfull" {
+#   value       = [for x in netapp-gcp_volume.gcp-volume.mountpoints: x.exportfull if x.protocoltype == "NFSv4"][0]
+#   description = "The full export path of the cloud volume."
+# }

--- a/gcp/volume.go
+++ b/gcp/volume.go
@@ -36,11 +36,12 @@ type listVolumesRequest struct {
 
 // listVolumeResult lists the volume for given volume ID
 type listVolumeResult struct {
-	VolumeID              string `json:"volumeId"`
-	VolumeName            string `json:"name"`
-	CreationToken         string `json:"creationToken"`
-	LifeCycleState        string `json:"lifeCycleState"`
-	LifeCycleStateDetails string `json:"lifeCycleStateDetails"`
+	VolumeID              string       `json:"volumeId"`
+	VolumeName            string       `json:"name"`
+	CreationToken         string       `json:"creationToken"`
+	LifeCycleState        string       `json:"lifeCycleState"`
+	LifeCycleStateDetails string       `json:"lifeCycleStateDetails"`
+	MountPoints           []mountPoint `json:"mountPoints"`
 }
 
 // listVolumesByNameRequest requests the volume for given volume ID and region
@@ -82,6 +83,13 @@ type createVolumeCreationTokenResult struct {
 type deleteVolumeRequest struct {
 	VolumeID string `structs:"volumeId"`
 	Region   string `structs:"region"`
+}
+
+type mountPoint struct {
+	Export       string `structs:"export"`
+	ExportFull   string `structs:"exportFull"`
+	ProtocolType string `structs:"protocolType"`
+	Server       string `structs:"server"`
 }
 
 type snapshotPolicy struct {


### PR DESCRIPTION
This PR fixes #5 by adding the following exported attributes:

<provider_name>.<resource_name>.mountpoints[].server
<provider_name>.<resource_name>.mountpoints[].export
<provider_name>.<resource_name>.mountpoints[].exportfull
<provider_name>.<resource_name>.mountpoints[].protocoltype

These attributes can be obtained with "terraform output" or can be used in a module, e.g. for mounting a newly created volume to an VM.

An output.tf example file is provided to document usage.

Currently CVS only returns mountpoint[0], except when exporting NFSv3+NFSv4.
