### PR TITLE
Adding support for Active Directory organizational units (OU)

### DIFF
--- a/examples/gcp/active_directory/resources.tf
+++ b/examples/gcp/active_directory/resources.tf
@@ -6,4 +6,5 @@ resource "netapp-gcp_active_directory" "gcp-active-directory" {
   domain = "example.com"
   dns_server = "10.0.0.0"
   net_bios = "cvserve1"
+  organizational_unit = "OU=engineering"
 }

--- a/examples/gcp/active_directory/resources.tf
+++ b/examples/gcp/active_directory/resources.tf
@@ -7,4 +7,5 @@ resource "netapp-gcp_active_directory" "gcp-active-directory" {
   dns_server = "10.0.0.0"
   net_bios = "cvserve1"
   organizational_unit = "OU=engineering"
+  site = "Default-First-Site-Name"
 }

--- a/examples/gcp/active_directory/variables.tf
+++ b/examples/gcp/active_directory/variables.tf
@@ -1,4 +1,4 @@
-variable "gcp_project" {
+variable "gcp_project_number" {
   type = string
 }
 

--- a/gcp/active_directory.go
+++ b/gcp/active_directory.go
@@ -3,19 +3,20 @@ package gcp
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/fatih/structs"
 	"log"
+	"github.com/fatih/structs"
 )
 
 // operateActiveDirectoryRequest requests the user's input for creating/updating an active directory
 type operateActiveDirectoryRequest struct {
-	Username string `structs:"username"`
-	Password string `structs:"password"`
-	Region   string `structs:"region"`
-	Domain   string `structs:"domain"`
-	DNS      string `structs:"DNS"`
-	NetBIOS  string `structs:"netBIOS"`
-	UUID     string `structs:"UUID"`
+	Username           string `structs:"username"`
+	Password           string `structs:"password"`
+	Region             string `structs:"region"`
+	Domain             string `structs:"domain"`
+	DNS                string `structs:"DNS"`
+	NetBIOS            string `structs:"netBIOS"`
+	OrganizationalUnit string `structs:"organizationalUnit"`
+	UUID               string `structs:"UUID"`
 }
 
 // operateActiveDirectoryResult returns the api response for creating/updating an active directory
@@ -32,13 +33,14 @@ type listActiveDirectoryRequest struct {
 
 // listActiveDirectoryResult lists the active directory for given ID
 type listActiveDirectoryResult struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-	Region   string `json:"region"`
-	Domain   string `json:"domain"`
-	DNS      string `json:"DNS"`
-	NetBIOS  string `json:"netBIOS"`
-	UUID     string `json:"UUID"`
+	Username           string `json:"username"`
+	Password           string `json:"password"`
+	Region             string `json:"region"`
+	Domain             string `json:"domain"`
+	DNS                string `json:"DNS"`
+	NetBIOS            string `json:"netBIOS"`
+	OrganizationalUnit string `structs:"organizationalUnit"`
+	UUID               string `json:"UUID"`
 }
 
 type listActiveDirectoryApiResult struct {

--- a/gcp/active_directory.go
+++ b/gcp/active_directory.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+
 	"github.com/fatih/structs"
 )
 
@@ -16,6 +17,7 @@ type operateActiveDirectoryRequest struct {
 	DNS                string `structs:"DNS"`
 	NetBIOS            string `structs:"netBIOS"`
 	OrganizationalUnit string `structs:"organizationalUnit"`
+	Site               string `structs:"site"`
 	UUID               string `structs:"UUID"`
 }
 
@@ -40,6 +42,7 @@ type listActiveDirectoryResult struct {
 	DNS                string `json:"DNS"`
 	NetBIOS            string `json:"netBIOS"`
 	OrganizationalUnit string `structs:"organizationalUnit"`
+	Site               string `structs:"site"`
 	UUID               string `json:"UUID"`
 }
 

--- a/gcp/resource_netapp_gcp_active_directory.go
+++ b/gcp/resource_netapp_gcp_active_directory.go
@@ -2,9 +2,10 @@ package gcp
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/netapp/terraform-provider-netapp-gcp/gcp/cvs/restapi"
-	"log"
 )
 
 func resourceGCPActiveDirectory() *schema.Resource {
@@ -41,7 +42,11 @@ func resourceGCPActiveDirectory() *schema.Resource {
 			},
 			"organizational_unit": {
 				Type:     schema.TypeString,
-				Optional:     true,
+				Optional: true,
+			},
+			"site": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"region": {
 				Type:     schema.TypeString,
@@ -78,6 +83,9 @@ func resourceGCPActiveDirectoryCreate(d *schema.ResourceData, meta interface{}) 
 	active_directory.NetBIOS = d.Get("net_bios").(string)
 	if v, ok := d.GetOk("organizational_unit"); ok {
 		active_directory.OrganizationalUnit = v.(string)
+	}
+	if v, ok := d.GetOk("site"); ok {
+		active_directory.Site = v.(string)
 	}
 	active_directory.Region = d.Get("region").(string)
 
@@ -119,6 +127,10 @@ func resourceGCPActiveDirectoryRead(d *schema.ResourceData, meta interface{}) er
 
 	if err := d.Set("organizational_unit", res.OrganizationalUnit); err != nil {
 		return fmt.Errorf("Error reading active directory organizational_unit: %s", err)
+	}
+
+	if err := d.Set("site", res.Site); err != nil {
+		return fmt.Errorf("Error reading active directory site: %s", err)
 	}
 
 	if err := d.Set("username", res.Username); err != nil {
@@ -188,6 +200,7 @@ func resourceGCPActiveDirectoryUpdate(d *schema.ResourceData, meta interface{}) 
 	active_directory.DNS = d.Get("dns_server").(string)
 	active_directory.NetBIOS = d.Get("net_bios").(string)
 	active_directory.OrganizationalUnit = d.Get("organizational_unit").(string)
+	active_directory.Site = d.Get("site").(string)
 	active_directory.Region = d.Get("region").(string)
 	active_directory.UUID = d.Get("uuid").(string)
 	err := client.updateActiveDirectory(active_directory)

--- a/gcp/resource_netapp_gcp_active_directory.go
+++ b/gcp/resource_netapp_gcp_active_directory.go
@@ -39,6 +39,10 @@ func resourceGCPActiveDirectory() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"organizational_unit": {
+				Type:     schema.TypeString,
+				Optional:     true,
+			},
 			"region": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -72,6 +76,9 @@ func resourceGCPActiveDirectoryCreate(d *schema.ResourceData, meta interface{}) 
 	active_directory.Domain = d.Get("domain").(string)
 	active_directory.DNS = d.Get("dns_server").(string)
 	active_directory.NetBIOS = d.Get("net_bios").(string)
+	if v, ok := d.GetOk("organizational_unit"); ok {
+		active_directory.OrganizationalUnit = v.(string)
+	}
 	active_directory.Region = d.Get("region").(string)
 
 	res, err := client.createActiveDirectory(&active_directory)
@@ -108,6 +115,10 @@ func resourceGCPActiveDirectoryRead(d *schema.ResourceData, meta interface{}) er
 
 	if err := d.Set("net_bios", res.NetBIOS); err != nil {
 		return fmt.Errorf("Error reading active directory net_bios: %s", err)
+	}
+
+	if err := d.Set("organizational_unit", res.OrganizationalUnit); err != nil {
+		return fmt.Errorf("Error reading active directory organizational_unit: %s", err)
 	}
 
 	if err := d.Set("username", res.Username); err != nil {
@@ -176,6 +187,7 @@ func resourceGCPActiveDirectoryUpdate(d *schema.ResourceData, meta interface{}) 
 	active_directory.Domain = d.Get("domain").(string)
 	active_directory.DNS = d.Get("dns_server").(string)
 	active_directory.NetBIOS = d.Get("net_bios").(string)
+	active_directory.OrganizationalUnit = d.Get("organizational_unit").(string)
 	active_directory.Region = d.Get("region").(string)
 	active_directory.UUID = d.Get("uuid").(string)
 	err := client.updateActiveDirectory(active_directory)

--- a/gcp/resource_netapp_gcp_active_directory_test.go
+++ b/gcp/resource_netapp_gcp_active_directory_test.go
@@ -2,9 +2,10 @@ package gcp
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"testing"
 )
 
 func TestAccActiveDirectory_basic(t *testing.T) {
@@ -28,6 +29,7 @@ func TestAccActiveDirectory_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("netapp-gcp_active_directory.terraform-acceptance-test-1", "domain", "example.com"),
 					resource.TestCheckResourceAttr("netapp-gcp_active_directory.terraform-acceptance-test-1", "dns_server", "10.0.0.0"),
 					resource.TestCheckResourceAttr("netapp-gcp_active_directory.terraform-acceptance-test-1", "net_bios", "cvserver"),
+					resource.TestCheckResourceAttr("netapp-gcp_active_directory.terraform-acceptance-test-1", "organizational_unit", "CN=Computers"),
 				),
 			},
 			{
@@ -39,6 +41,7 @@ func TestAccActiveDirectory_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("netapp-gcp_active_directory.terraform-acceptance-test-1", "domain", "newExample.com"),
 					resource.TestCheckResourceAttr("netapp-gcp_active_directory.terraform-acceptance-test-1", "dns_server", "10.0.0.1"),
 					resource.TestCheckResourceAttr("netapp-gcp_active_directory.terraform-acceptance-test-1", "net_bios", "cvservers"),
+					resource.TestCheckResourceAttr("netapp-gcp_active_directory.terraform-acceptance-test-1", "organizational_unit", "OU=engineering"),
 					testAccWaitSeconds(10),
 				),
 			},
@@ -123,6 +126,7 @@ func testAccActiveDirectoryConfigUpdate() string {
 		domain = "newExample.com"
 		dns_server = "10.0.0.1"
 		net_bios = "cvservers"
+		organizational_unit = "OU=engineering"
 	  }
 	`)
 }

--- a/gcp/resource_netapp_gcp_volume.go
+++ b/gcp/resource_netapp_gcp_volume.go
@@ -463,6 +463,10 @@ func resourceGCPVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
 	// size is always required.
 	volume.Size = d.Get("size").(int) * GiBToBytes
 
+	if d.HasChange("name") {
+		makechange = 1
+	}
+
 	if d.HasChange("size") {
 		makechange = 1
 	}

--- a/gcp/volume.go
+++ b/gcp/volume.go
@@ -3,9 +3,10 @@ package gcp
 import (
 	"encoding/json"
 	"fmt"
+	"log"
+
 	"github.com/fatih/structs"
 	"github.com/hashicorp/terraform/helper/schema"
-	"log"
 )
 
 // volumeRequest the users input for creating,requesting,updateing a Volume


### PR DESCRIPTION
Complex active directories organise resources like computers and users into sub-partitions, called Organizational Units (OU). This is a common requirement for all, but the smallest, Active Directories.

While the CVS API offers the functionality to set the OU, the current CVS/GCP UI misses that functionality. This PR enables OU handling for the Terraform provider.

Note to maintainers: I also added checks into active directory acceptance tests. I cannot test this, but should work fine without issues. Please note, that you have to add an OU called "engineering" to your test AD, if you want to create volumes after you set OU=engineering. Otherwise SMB volume create will fail, because the OU doesn't exist.

