### PR TITLE
Add GCP validation for project and shared_vpc_project_number

### DIFF
--- a/gcp/provider.go
+++ b/gcp/provider.go
@@ -1,7 +1,10 @@
 package gcp
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -10,10 +13,11 @@ func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"project": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("GCP_PROJECT", nil),
-				Description: "The project for GCP API operations.",
+				Type:         schema.TypeString,
+				Required:     true,
+				DefaultFunc:  schema.EnvDefaultFunc("GCP_PROJECT", nil),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[0-9]+$"), "project must be an numerical project number"),
+				Description:  "The project number for GCP API operations.",
 			},
 			"service_account": {
 				Type:        schema.TypeString,

--- a/gcp/resource_netapp_gcp_active_directory.go
+++ b/gcp/resource_netapp_gcp_active_directory.go
@@ -25,8 +25,9 @@ func resourceGCPActiveDirectory() *schema.Resource {
 				Required: true,
 			},
 			"password": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
 			},
 			"domain": {
 				Type:     schema.TypeString,

--- a/gcp/resource_netapp_gcp_volume.go
+++ b/gcp/resource_netapp_gcp_volume.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 	"time"
+	"regexp"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -64,8 +65,9 @@ func resourceGCPVolume() *schema.Resource {
 				Computed: true,
 			},
 			"shared_vpc_project_number": {
-				Type: schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[0-9]+$"), "shared_vpc_project_number must be an numerical project number"),
 			},
 			"mount_points": {
 				Type:     schema.TypeList,
@@ -320,7 +322,7 @@ func resourceGCPVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if v,ok := d.GetOk("shared_vpc_project_number"); ok{
+	if v, ok := d.GetOk("shared_vpc_project_number"); ok {
 		volume.Shared_vpc_project_number = v.(string)
 	}
 

--- a/gcp/volume.go
+++ b/gcp/volume.go
@@ -3,25 +3,26 @@ package gcp
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/fatih/structs"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"time"
+
+	"github.com/fatih/structs"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 // volumeRequest the users input for creating,requesting,updateing a Volume
 // exportPolicy can't set to omitempty because it could be deleted during update.
 type volumeRequest struct {
-	Name           string         `structs:"name,omitempty"`
-	Region         string         `structs:"region,omitempty"`
-	CreationToken  string         `structs:"creationToken,omitempty"`
-	ProtocolTypes  []string       `structs:"protocolTypes,omitempty"`
-	Network        string         `structs:"network,omitempty"`
-	Size           int            `structs:"quotaInBytes,omitempty"`
-	ServiceLevel   string         `structs:"serviceLevel,omitempty"`
-	SnapshotPolicy snapshotPolicy `structs:"snapshotPolicy,omitempty"`
-	ExportPolicy   exportPolicy   `structs:"exportPolicy"`
-	VolumeID       string         `structs:"volumeId,omitempty"`
+	Name                      string         `structs:"name,omitempty"`
+	Region                    string         `structs:"region,omitempty"`
+	CreationToken             string         `structs:"creationToken,omitempty"`
+	ProtocolTypes             []string       `structs:"protocolTypes,omitempty"`
+	Network                   string         `structs:"network,omitempty"`
+	Size                      int            `structs:"quotaInBytes,omitempty"`
+	ServiceLevel              string         `structs:"serviceLevel,omitempty"`
+	SnapshotPolicy            snapshotPolicy `structs:"snapshotPolicy,omitempty"`
+	ExportPolicy              exportPolicy   `structs:"exportPolicy"`
+	VolumeID                  string         `structs:"volumeId,omitempty"`
 	Shared_vpc_project_number string
 }
 
@@ -245,7 +246,7 @@ func (c *Client) createVolume(request *volumeRequest) (createVolumeResult, error
 	var projectID string
 	if request.Shared_vpc_project_number != "" {
 		projectID = request.Shared_vpc_project_number
-	} else{
+	} else {
 		projectID = c.GetProjectID()
 	}
 	request.Network = fmt.Sprintf("projects/%s/global/networks/%s", projectID, request.Network)
@@ -413,17 +414,17 @@ func expandSnapshotPolicy(data map[string]interface{}) snapshotPolicy {
 	}
 	if v, ok := data["monthly_schedule"]; ok {
 		if len(v.([]interface{})) > 0 {
-			montly_schedule := v.([]interface{})[0].(map[string]interface{})
-			if days_of_month, ok := montly_schedule["days_of_month"]; ok {
+			monthly_schedule := v.([]interface{})[0].(map[string]interface{})
+			if days_of_month, ok := monthly_schedule["days_of_month"]; ok {
 				snapshot_policy.MonthlySchedule.DaysOfMonth = days_of_month.(string)
 			}
-			if hour, ok := montly_schedule["hour"]; ok {
+			if hour, ok := monthly_schedule["hour"]; ok {
 				snapshot_policy.MonthlySchedule.Hour = hour.(int)
 			}
-			if minute, ok := montly_schedule["minute"]; ok {
+			if minute, ok := monthly_schedule["minute"]; ok {
 				snapshot_policy.MonthlySchedule.Minute = minute.(int)
 			}
-			if snapshotsToKeep, ok := montly_schedule["snapshots_to_keep"]; ok {
+			if snapshotsToKeep, ok := monthly_schedule["snapshots_to_keep"]; ok {
 				snapshot_policy.MonthlySchedule.SnapshotsToKeep = snapshotsToKeep.(int)
 			}
 		}


### PR DESCRIPTION
This PR contains three commits.

1. Fix typo (montly -> monthly) in variable name. Cosmetic

2. Add validation for "project" and "shared_vpc_project_number" attributes
On GCP, users often confuse project_ID (mostly used within GCP) and project_number (which the CVS API uses). This led to multiple annoyances when users specified the alpha-numerical project_ID , instead of the numerical project_number. When doing so, the error message is less than helpful:

```log
netapp-gcp_volume.gcp-volume: Creating...

Error: invalid character '<' looking for beginning of value

  on volume.tf line 3, in resource "netapp-gcp_volume" "gcp-volume":
   3: resource "netapp-gcp_volume" "gcp-volume" {
```
This commit adds a validation to "project" and "shared_vpc_project_number" to be numeric. Since project_id needs to start with a lowercase letter, this will prevent users from specifying a project_id and will return an helpful error message. The commit misses tests to test the validation. Manual tests did work.

3. Mark the password field of Active Directory username/password as sensitive. Terraform will stop printing its content, but will print "(sensitive value)" instead.

Additionally, my editor (VSCode) enforces some formatting rules automatically. Some lines got cleaned up.
