### PR TITLE
Example refresh #3 - storage_class

### DIFF
--- a/examples/gcp/provider.tf
+++ b/examples/gcp/provider.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     netapp-gcp = {
       source = "NetApp/netapp-gcp"
-      version = "~> 20.10.0"
+      version = "~> 20.11.1"
     }
   }
 }

--- a/examples/gcp/volume/advanced/variables.tf
+++ b/examples/gcp/volume/advanced/variables.tf
@@ -45,6 +45,18 @@ variable "service_level" {
   default     = "medium"
 }
 
+variable "storage_class" {
+  type        = string
+  description = "Type of CVS service: CVS=software, CVS-Performance=hardware."
+  default     = "hardware"
+}
+
+variable "zone" {
+  type        = string
+  description = "GCP zone CVS-Software is deployed to. Required for CVS-Software."
+  default     = null
+}
+
 variable "ad_username" {
   type        = string
   description = "Active Directory username for joining domain."

--- a/examples/gcp/volume/advanced/variables.tf
+++ b/examples/gcp/volume/advanced/variables.tf
@@ -41,8 +41,8 @@ variable "size" {
 
 variable "service_level" {
   type        = string
-  description = "Service level low, medium or high."
-  default     = "medium"
+  description = "Service level standard, premium or extreme."
+  default     = "premium"
 }
 
 variable "storage_class" {

--- a/examples/gcp/volume/advanced/volume.auto.tfvars
+++ b/examples/gcp/volume/advanced/volume.auto.tfvars
@@ -4,3 +4,5 @@ protocol = ["NFSv3"]
 size = 1024
 service_level = "premium"
 network = "ncv-vpc"
+storage_class = "hardware"
+# zone = "europe-west1-b"

--- a/examples/gcp/volume/advanced/volume.tf
+++ b/examples/gcp/volume/advanced/volume.tf
@@ -8,6 +8,10 @@ resource "netapp-gcp_volume" "gcp-volume" {
   network = var.network
   size = var.size
   service_level = var.service_level
+  # storage_class: choose "software for CVS, choose "hardware" for CVS-Performance
+  storage_class = var.storage_class
+  # zone: For storage_class = "software" specification of zone is required
+  # zone = var.zone
 
   snapshot_policy {
     enabled = true

--- a/examples/gcp/volume/minimal/minimal.tf
+++ b/examples/gcp/volume/minimal/minimal.tf
@@ -21,4 +21,8 @@ resource "netapp-gcp_volume" "gcp-minimal-volume" {
   network = local.network
   size = local.size
   service_level = local.service_level
+  # storage_class: choose "software for CVS, choose "hardware" for CVS-Performance
+  storage_class = "hardware"
+  # zone: For storage_class = "software" specification of zone is required
+  # zone = "europe-west1-b"
 }

--- a/examples/gcp/volume/minimal/minimal.tf
+++ b/examples/gcp/volume/minimal/minimal.tf
@@ -25,4 +25,8 @@ resource "netapp-gcp_volume" "gcp-minimal-volume" {
   storage_class = "hardware"
   # zone: For storage_class = "software" specification of zone is required
   # zone = "europe-west1-b"
+  # when using storage_class = "software", enabling snapshot_policy is required
+  # snapshot_policy {
+  #   enabled = true
+  # }
 }

--- a/examples/gcp/volume/volume-batch/volume-nfs.tf
+++ b/examples/gcp/volume/volume-batch/volume-nfs.tf
@@ -23,7 +23,11 @@ resource "netapp-gcp_volume" "gcp-volumes-batch" {
   network = local.network
   size = local.volumes[count.index].size
   service_level = local.volumes[count.index].service_level
-  
+  # storage_class: choose "software for CVS, choose "hardware" for CVS-Performance
+  storage_class = "hardware"
+  # zone: For storage_class = "software" specification of zone is required
+  # zone = "europe-west1-b"
+
   snapshot_policy {
     enabled = true
     daily_schedule {

--- a/examples/gcp/volume/volume-nfs/volume-nfs.tf
+++ b/examples/gcp/volume/volume-nfs/volume-nfs.tf
@@ -16,6 +16,10 @@ resource "netapp-gcp_volume" "gcp-volume-nfs" {
   network = local.network
   size = local.size
   service_level = local.service_level
+  # storage_class: choose "software for CVS, choose "hardware" for CVS-Performance
+  storage_class = "hardware"
+  # zone: For storage_class = "software" specification of zone is required
+  # zone = "europe-west1-b"
  
   # up to 5 export rules
   export_policy {
@@ -67,4 +71,3 @@ resource "netapp-gcp_volume" "gcp-volume-nfs" {
     }    
   }
 }
-

--- a/examples/gcp/volume/volume-smb/volume-smb.tf
+++ b/examples/gcp/volume/volume-smb/volume-smb.tf
@@ -21,6 +21,10 @@ resource "netapp-gcp_volume" "gcp-volume-smb" {
   network = local.network
   size = local.size
   service_level = local.service_level
+  # storage_class: choose "software for CVS, choose "hardware" for CVS-Performance
+  storage_class = "hardware"
+  # zone: For storage_class = "software" specification of zone is required
+  # zone = "europe-west1-b"
 
   # Advice: Since SMB volumes can only be created if an Active Directory connection exists for the region,
   # depend the SMB volume on the AD resource. Either create the AD from TF, or use AD data source to query for


### PR DESCRIPTION
Multiple users experiences issues recently when using CVS-Software. When using CVS-Software, the "zone" parameter becomes required. This is poorly documented.
This PR updates the volume examples to explicitly specify the "storage_class" attribute and documentation explaining that "zone" is required for "storage_class=software".