### PR TITLE
NFS changes 2020.11

### DIFF
--- a/examples/gcp/volume/volume-nfs/volume-nfs.tf
+++ b/examples/gcp/volume/volume-nfs/volume-nfs.tf
@@ -24,20 +24,28 @@ resource "netapp-gcp_volume" "gcp-volume-nfs" {
   # up to 5 export rules
   export_policy {
     rule {
-      allowed_clients = "0.0.0.0/0"
-      access= "ReadOnly"
+      allowed_clients = "10.10.7.0/24"
+      access = "ReadWrite"
+      has_root_access = true
+      kerberos5_readonly = false
+      kerberos5_readwrite = false
+      kerberos5i_readonly = false
+      kerberos5i_readwrite = false
+      kerberos5p_readonly = false
+      kerberos5p_readwrite = false
       nfsv3 {
-        checked =  true
+        checked = true
       }
       nfsv4 {
         checked = false
       }
     }
     rule {
-      allowed_clients = "10.10.20.0/24"
-      access= "ReadWrite"
+      allowed_clients = "0.0.0.0/0"
+      access = "ReadOnly"
+      has_root_access = false
       nfsv3 {
-        checked =  true
+        checked = true
       }
       nfsv4 {
         checked = false

--- a/gcp/data_source_gcp_volume.go
+++ b/gcp/data_source_gcp_volume.go
@@ -16,6 +16,10 @@ func dataSourceGCPVolume() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"type_dp": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"region": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -165,7 +169,7 @@ func dataSourceGCPVolume() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"rule": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -175,6 +179,34 @@ func dataSourceGCPVolume() *schema.Resource {
 									},
 									"allowed_clients": {
 										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"has_root_access": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"kerberos5_readonly": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"kerberos5_readwrite": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"kerberos5i_readonly": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"kerberos5i_readwrite": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"kerberos5p_readonly": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"kerberos5p_readwrite": {
+										Type:     schema.TypeBool,
 										Computed: true,
 									},
 									"nfsv3": {
@@ -207,6 +239,14 @@ func dataSourceGCPVolume() *schema.Resource {
 					},
 				},
 			},
+			"zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"storage_class": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -229,6 +269,9 @@ func dataSourceGCPVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(res.VolumeID)
 	if err := d.Set("name", res.Name); err != nil {
 		return fmt.Errorf("Error reading volume name: %s", err)
+	}
+	if err := d.Set("type_dp", res.TypeDP); err != nil {
+		return fmt.Errorf("Error reading type_dp: %s", err)
 	}
 	if err := d.Set("size", res.Size/GiBToBytes); err != nil {
 		return fmt.Errorf("Error reading volume size: %s", err)
@@ -276,6 +319,12 @@ func dataSourceGCPVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	mountPoints := flattenMountPoints(res.MountPoints)
 	if err := d.Set("mount_points", mountPoints); err != nil {
 		return fmt.Errorf("Error reading volume mount_points: %s", err)
+	}
+	if err := d.Set("zone", res.Zone); err != nil {
+		return fmt.Errorf("Error reading zone: %s", err)
+	}
+	if err := d.Set("storage_class", res.StorageClass); err != nil {
+		return fmt.Errorf("Error reading storage_class: %s", err)
 	}
 	return nil
 }

--- a/gcp/data_source_gcp_volume.go
+++ b/gcp/data_source_gcp_volume.go
@@ -266,6 +266,15 @@ func dataSourceGCPVolumeRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	// GH Issue #31: getVolumeByNameOrCreationToken doesn't return all required attributes
+	// snapshot_policy and export_policy are missing
+	// so we do getVolumeByID with the ID we just determined
+	volume.VolumeID = res.VolumeID
+	res, err = client.getVolumeByID(volume)
+	if err != nil {
+		return err
+	}
+
 	d.SetId(res.VolumeID)
 	if err := d.Set("name", res.Name); err != nil {
 		return fmt.Errorf("Error reading volume name: %s", err)

--- a/gcp/resource_netapp_gcp_volume.go
+++ b/gcp/resource_netapp_gcp_volume.go
@@ -219,7 +219,7 @@ func resourceGCPVolume() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"rule": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/gcp/resource_netapp_gcp_volume.go
+++ b/gcp/resource_netapp_gcp_volume.go
@@ -231,6 +231,41 @@ func resourceGCPVolume() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
+									"has_root_access": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  true,
+									},
+									"kerberos5_readonly": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"kerberos5_readwrite": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"kerberos5i_readonly": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"kerberos5i_readwrite": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"kerberos5p_readonly": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"kerberos5p_readwrite": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
 									"nfsv3": {
 										Type:     schema.TypeSet,
 										Optional: true,

--- a/gcp/volume.go
+++ b/gcp/volume.go
@@ -50,6 +50,7 @@ type volumeResult struct {
 	MountPoints           []mountPoints  `json:"mountPoints,omitempty"`
 	Zone                  string         `json:"zone,omitempty"`
 	StorageClass          string         `json:"storageClass,omitempty"`
+	TypeDP                bool           `json:"isDataProtection,omitempty"`
 }
 
 // createVolumeResult the api response for creating a volume

--- a/gcp/volume.go
+++ b/gcp/volume.go
@@ -579,9 +579,9 @@ func expandExportPolicy(set *schema.Set) exportPolicy {
 
 	for _, v := range set.List() {
 		rules := v.(map[string]interface{})
-		ruleSet := rules["rule"].(*schema.Set)
-		ruleConfigs := make([]exportPolicyRule, 0, ruleSet.Len())
-		for _, x := range ruleSet.List() {
+		ruleSet := rules["rule"].([]interface{})
+		ruleConfigs := make([]exportPolicyRule, 0, len(ruleSet))
+		for _, x := range ruleSet {
 			exportPolicyRule := exportPolicyRule{}
 			ruleConfig := x.(map[string]interface{})
 			exportPolicyRule.Access = ruleConfig["access"].(string)

--- a/gcp/volume.go
+++ b/gcp/volume.go
@@ -108,10 +108,17 @@ type apiResponseCodeMessage struct {
 }
 
 type exportPolicyRule struct {
-	Access         string `structs:"access"`
-	AllowedClients string `structs:"allowedClients"`
-	Nfsv3          nfs    `structs:"nfsv3"`
-	Nfsv4          nfs    `structs:"nfsv4"`
+	Access              string `structs:"access"`
+	AllowedClients      string `structs:"allowedClients"`
+	HasRootAccess       bool   `structs:"hasRootAccess"`
+	Kerberos5ReadOnly   bool   `structs:"kerberos5ReadOnly"`
+	Kerberos5ReadWrite  bool   `structs:"kerberos5ReadWrite"`
+	Kerberos5iReadOnly  bool   `structs:"kerberos5iReadOnly"`
+	Kerberos5iReadWrite bool   `structs:"kerberos5iReadWrite"`
+	Kerberos5pReadOnly  bool   `structs:"kerberos5pReadOnly"`
+	Kerberos5pReadWrite bool   `structs:"kerberos5pReadWrite"`
+	Nfsv3               nfs    `structs:"nfsv3"`
+	Nfsv4               nfs    `structs:"nfsv4"`
 }
 
 type exportPolicy struct {
@@ -539,6 +546,13 @@ func flattenExportPolicy(v exportPolicy) interface{} {
 		ruleMap := make(map[string]interface{})
 		ruleMap["access"] = exportPolicyRule.Access
 		ruleMap["allowed_clients"] = exportPolicyRule.AllowedClients
+		ruleMap["has_root_access"] = exportPolicyRule.HasRootAccess
+		ruleMap["kerberos5_readonly"] = exportPolicyRule.Kerberos5ReadOnly
+		ruleMap["kerberos5_readwrite"] = exportPolicyRule.Kerberos5ReadWrite
+		ruleMap["kerberos5i_readonly"] = exportPolicyRule.Kerberos5iReadOnly
+		ruleMap["kerberos5i_readwrite"] = exportPolicyRule.Kerberos5iReadWrite
+		ruleMap["kerberos5p_readonly"] = exportPolicyRule.Kerberos5pReadOnly
+		ruleMap["kerberos5p_readwrite"] = exportPolicyRule.Kerberos5pReadWrite
 		nfsv3Config := make(map[string]interface{})
 		nfsv4Config := make(map[string]interface{})
 		nfsv3Config["checked"] = exportPolicyRule.Nfsv3.Checked
@@ -572,6 +586,13 @@ func expandExportPolicy(set *schema.Set) exportPolicy {
 			ruleConfig := x.(map[string]interface{})
 			exportPolicyRule.Access = ruleConfig["access"].(string)
 			exportPolicyRule.AllowedClients = ruleConfig["allowed_clients"].(string)
+			exportPolicyRule.HasRootAccess = ruleConfig["has_root_access"].(bool)
+			exportPolicyRule.Kerberos5ReadOnly = ruleConfig["kerberos5_readonly"].(bool)
+			exportPolicyRule.Kerberos5ReadWrite = ruleConfig["kerberos5_readwrite"].(bool)
+			exportPolicyRule.Kerberos5iReadOnly = ruleConfig["kerberos5i_readonly"].(bool)
+			exportPolicyRule.Kerberos5iReadWrite = ruleConfig["kerberos5i_readwrite"].(bool)
+			exportPolicyRule.Kerberos5pReadOnly = ruleConfig["kerberos5p_readonly"].(bool)
+			exportPolicyRule.Kerberos5pReadWrite = ruleConfig["kerberos5p_readwrite"].(bool)
 			nfsv3Set := ruleConfig["nfsv3"].(*schema.Set)
 			nfsv4Set := ruleConfig["nfsv4"].(*schema.Set)
 			for _, y := range nfsv3Set.List() {


### PR DESCRIPTION
This is some work to incorporate the NFS changes of CVS November 2020 release.

First commit adds the following export_policy rule attributes (with default values):
      has_root_access = true
      kerberos5_readonly = false
      kerberos5_readwrite = false
      kerberos5i_readonly = false
      kerberos5i_readwrite = false
      kerberos5p_readonly = false
      kerberos5p_readwrite = false

has_root_access=true correspond to no_root_squash on some other NFS daemons. I tested it using the expanded [volumes-nfs](examples/gcp/volume/volume-nfs) example and it works as expected. 

The other 6 attributes enable kerberos (KRB5, KRB5i, KRB5p). The code the set the API accordingly works, but I haven't done actual Kerberized NFS tests. How to do this right with CVS might be better documented in a Blog or Documentation anyway.

The second commit fixes an existing error in export_policy. The order of the export rules is important. First match wins. The code used an unordered set, nor an ordered list.
