### PR TITLE
volumes: make Terraform import work

### DIFF
--- a/gcp/resource_netapp_gcp_volume.go
+++ b/gcp/resource_netapp_gcp_volume.go
@@ -595,18 +595,21 @@ func resourceGCPVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("volume_path", res.CreationToken); err != nil {
 		return fmt.Errorf("Error reading volume path or Creation Token: %s", err)
 	}
-	// res.Network either contains network name (for standalone project) or
-	// projects/${HOST_PROJECT_ID}/global/networks/${SHARED_VPC_NAME} for shared VPC
+	// res.Network either contains simple network name or
+	// projects/${HOST_PROJECT_ID}/global/networks/${SHARED_VPC_NAME}, usually (but not exclusively) for shared VPC
 	nws := strings.Split(res.Network, "/")
 	var network string
 	if len(nws) == 1 {
 		// standalone project network
 		network = nws[0]
 	} else if len(nws) == 5 {
-		// shared VPC network
+		// long network path
 		network = nws[4]
-		if err := d.Set("shared_vpc_project_number", nws[1]); err != nil {
-			return fmt.Errorf("Error reading shared_vpc_project_number: %s", err)
+		// if network path contains different projectId than our project, it is shared-VPC
+		if nws[1] != client.Project {
+			if err := d.Set("shared_vpc_project_number", nws[1]); err != nil {
+				return fmt.Errorf("Error reading shared_vpc_project_number: %s", err)
+			}
 		}
 	} else {
 		return fmt.Errorf("Error returned network path invalid: %s", res.Network)

--- a/gcp/resource_netapp_gcp_volume.go
+++ b/gcp/resource_netapp_gcp_volume.go
@@ -434,8 +434,8 @@ func resourceGCPVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 
 // Wait up to 15 minutes for volume creation to complete.
 func waitForVolumeCreationComplete(client *Client, volumeRes volumeResult) (volumeResult, error) {
-	waitSeconds := 900	// first volume creation can take 11 minutes
-	threshold := 900 -60	// when to warn
+	waitSeconds := 900    // first volume creation can take 11 minutes
+	threshold := 900 - 60 // when to warn
 	elapsed := time.Duration(0)
 	var err error
 	for waitSeconds > 0 && volumeRes.LifeCycleState == "creating" {
@@ -520,6 +520,10 @@ func resourceGCPVolumeRead(d *schema.ResourceData, meta interface{}) error {
 	} else if res.LifeCycleState == "deleted" {
 		d.SetId("")
 		return nil
+	}
+
+	if err := d.Set("name", res.Name); err != nil {
+		return fmt.Errorf("Error reading volume name: %s", err)
 	}
 
 	if err := d.Set("size", res.Size/GiBToBytes); err != nil {

--- a/gcp/volume.go
+++ b/gcp/volume.go
@@ -166,20 +166,18 @@ func (c *Client) getVolumeByID(volume volumeRequest) (volumeResult, error) {
 			return volumeResult{}, err
 		}
 
+		if len(volumes) == 0 {
+			return volumeResult{}, fmt.Errorf("getVolumeByID: No volume found with ID %s", volume.VolumeID)
+		}
+		if len(volumes) > 1 {
+			// return error message which tells user to rerun with ID = <volumeID>:<region> format
+			return volumeResult{}, fmt.Errorf(`getVolumeByID: More than one volume found with ID %s. \n
+			If this happend while running terraform import, please use \n
+			terraform import ADDR ID, with ID using <volumeID>:<region_name> format`, volume.VolumeID)
+		}
 		if len(volumes) == 1 {
 			// we found the right volume to import
 			volume.Region = volumes[0].Region
-		} else {
-			if len(volumes) == 0 {
-				return volumeResult{}, fmt.Errorf("getVolumeByID: No volume found with ID %s", volume.VolumeID)
-			}
-			if len(volumes) > 1 {
-				// return error message which tells user to rerun with ID = <volumeID>:<region> format
-				return volumeResult{}, fmt.Errorf(`getVolumeByID: More than one volume found with ID %s. \n
-				If this happend while running terraform import, please use \n
-				terraform import ADDR ID, with ID using <volumeID>:<region_name> format`, volume.VolumeID)
-			}
-			return volumeResult{}, fmt.Errorf("getVolumeByID: WTF error with volume ID %s", volume.VolumeID)
 		}
 	}
 

--- a/gcp/volume.go
+++ b/gcp/volume.go
@@ -187,48 +187,30 @@ func (c *Client) getVolumeByID(volume volumeRequest) (volumeResult, error) {
 	return result, nil
 }
 
-func (c *Client) getVolumeByRegion(region string) ([]volumeResult, error) {
+// refactored, but commented, since no code is using it currently
+// func (c *Client) getVolumeByRegion(region string) ([]volumeResult, error) {
+// 	return c.getVolumes(region)
+// }
+
+// Returns volumes of the project. region = "-" for all regions
+func (c *Client) getVolumes(region string) ([]volumeResult, error) {
 
 	baseURL := fmt.Sprintf("%s/Volumes", region)
-	var volumes []volumeResult
-
-	statusCode, response, err := c.CallAPIMethod("GET", baseURL, nil)
-	if err != nil {
-		log.Print("ListVolumes request failed")
-		return volumes, err
-	}
-
-	responseError := apiResponseChecker(statusCode, response, "getVolumeByRegion")
-	if responseError != nil {
-		return volumes, responseError
-	}
-
-	if err := json.Unmarshal(response, &volumes); err != nil {
-		log.Print("Failed to unmarshall response from getVolumeByRegion")
-		return volumes, err
-	}
-	return volumes, nil
-}
-
-// Returns all volumes of the project
-func (c *Client) getAllVolumes() ([]volumeResult, error) {
-
-	baseURL := fmt.Sprintf("-/Volumes")
 	var result []volumeResult
 
 	statusCode, response, err := c.CallAPIMethod("GET", baseURL, nil)
 	if err != nil {
-		log.Print("getAllVolumes request failed")
+		log.Print("getVolumes request failed")
 		return result, err
 	}
 
-	responseError := apiResponseChecker(statusCode, response, "getAllVolumes")
+	responseError := apiResponseChecker(statusCode, response, "getVolumes")
 	if responseError != nil {
 		return result, responseError
 	}
 
 	if err := json.Unmarshal(response, &result); err != nil {
-		log.Print("Failed to unmarshall response from getAllVolumes")
+		log.Print("Failed to unmarshall response from getVolumes")
 		return result, err
 	}
 	return result, nil
@@ -239,7 +221,7 @@ func (c *Client) getAllVolumes() ([]volumeResult, error) {
 func (c *Client) filterAllVolumes(f func(volumeResult) bool) ([]volumeResult, error) {
 	filteredVolumes := make([]volumeResult, 0)
 
-	vols, err := c.getAllVolumes()
+	vols, err := c.getVolumes("-")
 	if err != nil {
 		return filteredVolumes, err
 	}


### PR DESCRIPTION
This PR is a possible solution for volume import (see issue #33 ).

It implements approach number 1. It is the most simply solution and should work well, but will fail for the very unlikely corner case that more than one volume hold a volume with the requested volume UUID.

A proper importer which can also handle cases where multiple volumes with the same ID are found would be the cleaner solution.

This is how to use it:

1. Create an empty volume resource (volume.tf), e.g.:
```tf
resource "netapp-gcp_volume" "myvolume" {
}

```
2. Lookup the volumeID of the volume you want to import in the UI, e.g 6462b343-262c-e785-dc6c-ca5fcfc7e185.
3. Run the import
`terraform import netapp-gcp_volume.myvolume 6462b343-262c-e785-dc6c-ca5fcfc7e185
`
4. If it worked fine, TF will have imported the state of the volume into the terraform.tfstate file. Use 
`terraform show -no-color > volume.tf` to create the resource definition (overwriting the prior empty definition).
5. Delete the `id` line in volume.tf
6. Run `terraform plan`. If everything went fine, it should run without proposing changes.
7. Voila, you now have the definition in volume.tf and can start managing your volume with TF.

Happy to discuss.

