### PR TITLE
remove snap_reserve setting

### DIFF
--- a/gcp/resource_netapp_gcp_volume.go
+++ b/gcp/resource_netapp_gcp_volume.go
@@ -315,11 +315,6 @@ func resourceGCPVolume() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"snap_reserve": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  0,
-			},
 			"snapshot_directory": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -422,10 +417,6 @@ func resourceGCPVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 	if volume.StorageClass == "software" && ((volume.Zone == "" && volume.RegionalHA == false) || (volume.Zone != "" && volume.RegionalHA == true)) {
 		log.Print("Error creating volume")
 		return fmt.Errorf("If storage_class is software, zone or RegionalHA is mandatory")
-	}
-
-	if v, ok := d.GetOk("snap_reserve"); ok {
-		volume.SnapReserve = v.(int)
 	}
 
 	if v, ok := d.GetOk("unix_permissions"); ok {
@@ -682,9 +673,6 @@ func resourceGCPVolumeRead(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Error reading volume storage_class: %s", err)
 		}
 	}
-	if err := d.Set("snap_reserve", res.SnapReserve); err != nil {
-		return fmt.Errorf("Error reading volume snap_reserve: %s", err)
-	}
 	if err := d.Set("snapshot_directory", res.SnapshotDirectory); err != nil {
 		return fmt.Errorf("Error reading volume snapshot_directory: %s", err)
 	}
@@ -798,7 +786,6 @@ func resourceGCPVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
 	volume.Name = d.Get("name").(string)
 	// size is always required.
 	volume.Size = d.Get("size").(int) * GiBToBytes
-	volume.SnapReserve = d.Get("snap_reserve").(int)
 	volume.SnapshotDirectory = d.Get("snapshot_directory").(bool)
 
 	if d.HasChange("name") {
@@ -806,10 +793,6 @@ func resourceGCPVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("size") {
-		makechange = 1
-	}
-
-	if d.HasChange("snap_reserve") {
 		makechange = 1
 	}
 

--- a/gcp/volume.go
+++ b/gcp/volume.go
@@ -32,7 +32,6 @@ type volumeRequest struct {
 	Zone                   string         `structs:"zone,omitempty"`
 	StorageClass           string         `structs:"storageClass,omitempty"`
 	RegionalHA             bool           `structs:"regionalHA,omitempty"`
-	SnapReserve            int            `structs:"snapReserve"`
 	SnapshotDirectory      bool           `structs:"snapshotDirectory"`
 	UnixPermissions        string         `structs:"unixPermissions,omitempty"`
 	SharedVpcProjectNumber string
@@ -57,7 +56,6 @@ type volumeResult struct {
 	StorageClass          string         `json:"storageClass,omitempty"`
 	RegionalHA            bool           `json:"regionalHA,omitempty"`
 	TypeDP                bool           `json:"isDataProtection,omitempty"`
-	SnapReserve           int            `json:"snapReserve,omitempty"`
 	SnapshotDirectory     bool           `json:"snapshotDirectory,omitempty"`
 	UnixPermissions       string         `json:"unixPermissions,omitempty"`
 }

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -80,7 +80,6 @@ The following arguments are supported:
 * `shared_vpc_project_number` - (Optional) The host project number when deploying in a shared VPC service project.
 * `snapshot_policy` - (Optional) The set of Snapshot Policy attributes for volume.
 * `snapshot_directory` - (Optional) If enabled, the volume will contain a read-only .snapshot directory which provides access to each of the volume's snapshots. Default is true.
-* `snap_reserve` - (Optional) Percentage of volume storage reserved for snapshot storage. Default is 0 percent.
 * `storage_class` - (Optional) Storage Class to be provisioned. Allows the user to choose between hardware based or software based.
 * `type_dp` - (Optional) The type of the volume to be DP.
 * `unix_permissions` - (Optional) UNIX permissions for NFS volume accepted in octal 4 digit format. First digit selects the set user ID(4), set group ID (2) and sticky (1) attributes. Second digit selects permission for the owner of the file: read (4), write (2) and execute (1). Third selects permissions for other users in the same group. the fourth for other users not in the group. "0755" - gives read/write/execute permissions to owner and read/execute to group and other users.


### PR DESCRIPTION
This is a proposal for #54 and #55 .

I understand removing an option entirely might be too much. Maybe the better approach is deprecating it now and later remove it. I am unsure what the best way to deprecate feature in TF is.

On the other side, this setting is likely not used at all by users (maybe very few NTAP internal ones). Impact of removal is likely very limited. I vote to take the risk.
