### PR TITLE
kms_config: Add missing region parameter + fixes

### DIFF
--- a/gcp/kms.go
+++ b/gcp/kms.go
@@ -15,11 +15,12 @@ type kmsConfig struct {
 	ID              string `json:"UUID"`
 	KeyProjectID    string `json:"keyProjectID"`
 	Network         string `json:"network"`
+	Region          string `json:"region"`
 }
 
 func (c *Client) createKMSConfig(request *kmsConfig) (kmsConfig, error) {
 	params := structs.Map(request)
-	baseURL := fmt.Sprintf("%s/Storage/KmsConfig", request.KeyRingLocation)
+	baseURL := fmt.Sprintf("%s/Storage/KmsConfig", request.Region)
 	log.Printf("params: %#v", params)
 	statusCode, response, err := c.CallAPIMethod("POST", baseURL, params)
 	if err != nil {
@@ -43,7 +44,7 @@ func (c *Client) createKMSConfig(request *kmsConfig) (kmsConfig, error) {
 
 func (c *Client) getKMSConfig(request *kmsConfig) (kmsConfig, error) {
 	params := structs.Map(request)
-	baseURL := fmt.Sprintf("%s/Storage/KmsConfig/%s", request.KeyRingLocation, request.ID)
+	baseURL := fmt.Sprintf("%s/Storage/KmsConfig/%s", request.Region, request.ID)
 	statusCode, response, err := c.CallAPIMethod("GET", baseURL, params)
 	if err != nil {
 		log.Print("getKMSConfig request failed")
@@ -64,7 +65,7 @@ func (c *Client) getKMSConfig(request *kmsConfig) (kmsConfig, error) {
 
 func (c *Client) updateKMSConfig(request *kmsConfig) (kmsConfig, error) {
 	params := structs.Map(request)
-	baseURL := fmt.Sprintf("%s/Storage/KmsConfig/%s", request.KeyRingLocation, request.ID)
+	baseURL := fmt.Sprintf("%s/Storage/KmsConfig/%s", request.Region, request.ID)
 	statusCode, response, err := c.CallAPIMethod("PUT", baseURL, params)
 	if err != nil {
 		log.Print("updateKMSConfig request failed")
@@ -87,14 +88,14 @@ func (c *Client) updateKMSConfig(request *kmsConfig) (kmsConfig, error) {
 
 func (c *Client) deleteKMSConfig(request *kmsConfig) (kmsConfig, error) {
 	params := structs.Map(request)
-	baseURL := fmt.Sprintf("%s/Storage/KmsConfig/%s", request.KeyRingLocation, request.ID)
+	baseURL := fmt.Sprintf("%s/Storage/KmsConfig/%s", request.Region, request.ID)
 	statusCode, response, err := c.CallAPIMethod("DELETE", baseURL, params)
 	if err != nil {
 		log.Print("deleteKMSConfig request failed")
 		return kmsConfig{}, err
 	}
 
-	responseError := apiResponseChecker(statusCode, response, "deletteKMSConfig")
+	responseError := apiResponseChecker(statusCode, response, "deleteKMSConfig")
 	if responseError != nil {
 		return kmsConfig{}, responseError
 	}

--- a/gcp/resource_netapp_gcp_kms_config.go
+++ b/gcp/resource_netapp_gcp_kms_config.go
@@ -38,6 +38,10 @@ func resourceGCPKMSConfig() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
 		},
 	}
 }
@@ -50,6 +54,7 @@ func resourceGCPKMSConfigCreate(d *schema.ResourceData, meta interface{}) error 
 	kms.KeyName = d.Get("key_name").(string)
 	kms.KeyRingLocation = d.Get("key_ring_location").(string)
 	kms.Network = d.Get("network").(string)
+	kms.Region = d.Get("region").(string)
 
 	if v, ok := d.GetOk("key_project_id"); ok {
 		kms.KeyProjectID = v.(string)
@@ -62,7 +67,7 @@ func resourceGCPKMSConfigCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 	d.SetId(res.ID)
 
-	log.Printf("Created KMS in region: %v", kms.KeyRingLocation)
+	log.Printf("Created KMS in region: %v", kms.Region)
 
 	return resourceGCPKMSConfigRead(d, meta)
 }
@@ -71,7 +76,7 @@ func resourceGCPKMSConfigRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Client)
 	id := d.Id()
 	kmsConfig := kmsConfig{}
-	kmsConfig.KeyRingLocation = d.Get("key_ring_location").(string)
+	kmsConfig.Region = d.Get("region").(string)
 	kmsConfig.ID = d.Id()
 	res, err := client.getKMSConfig(&kmsConfig)
 	if err != nil {
@@ -94,7 +99,7 @@ func resourceGCPKMSConfigRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading key ring location: %s", err)
 	}
 
-	if _, ok := d.GetOk("key_projet_id"); ok {
+	if _, ok := d.GetOk("key_project_id"); ok {
 		if err := d.Set("key_project_id", res.KeyProjectID); err != nil {
 			return fmt.Errorf("Error reading key project id: %s", err)
 		}
@@ -104,6 +109,10 @@ func resourceGCPKMSConfigRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading network id: %s", err)
 	}
 
+	if err := d.Set("region", res.Region); err != nil {
+		return fmt.Errorf("Error reading region: %s", err)
+	}
+
 	return nil
 }
 
@@ -111,7 +120,7 @@ func resourceGCPKMSConfigDelete(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("Deleting kms: %#v", d)
 	client := meta.(*Client)
 	kms := kmsConfig{}
-	kms.KeyRingLocation = d.Get("key_ring_location").(string)
+	kms.Region = d.Get("region").(string)
 	kms.ID = d.Id()
 	_, deleteErr := client.deleteKMSConfig(&kms)
 	if deleteErr != nil {
@@ -131,6 +140,7 @@ func resourceGCPKMSConfigUpdate(d *schema.ResourceData, meta interface{}) error 
 	kms.KeyRing = d.Get("key_ring_name").(string)
 	kms.KeyRingLocation = d.Get("key_ring_location").(string)
 	kms.Network = d.Get("network").(string)
+	kms.Region = d.Get("region").(string)
 	kms.ID = d.Id()
 
 	if v, ok := d.GetOk("key_project_id"); ok {

--- a/website/docs/r/kms_config.html.markdown
+++ b/website/docs/r/kms_config.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a NetApp_GCP kms configuration resource. Volumes are encrypted at rest. The type of key used is determined at volume creation. 
 
-To use Customer-managed Encryption Keys (CMEK), use this resource to specify your CMEK in Google Cloud KMS instead. If no CMEK definition exists for the region, a service-managed key will be used instead.
+To use Customer-managed Encryption Keys (CMEK), use this resource to use a CMEK from Google Cloud KMS instead. If no CMEK definition exists for the region, a service-managed key will be used instead.
 
 ## Example Usages
 
@@ -19,10 +19,12 @@ To use Customer-managed Encryption Keys (CMEK), use this resource to specify you
 ```
 resource "netapp-gcp_kms_config" "kms-example" {
     provider = netapp-gcp
-    key_ring_location = "us-east4"
+    region = "us-central1"
+    key_project_id = "central-kms-key-project"
+    key_ring_location = "global"
     key_ring_name = "TheOneRing"
     key_name = "VirginiaKey"
-    network = "projects/{projectID}/global/networks/{network}"
+    network = "projects/{project_number}/global/networks/{vpc_name}"
 }
 ```
 
@@ -30,11 +32,12 @@ resource "netapp-gcp_kms_config" "kms-example" {
 
 The following arguments are supported:
 
+* `region` - (Required) Name of the region to create a KMS config for.
 * `key_name` - (Required, modifiable) Name of the key to be used for encryption. This key should be in the keyRing mentioned in keyRing field.
 * `key_project_id` - (Optional,modifiable) Project ID of project where the key to be used for encryption is residing. Use if key is located in different project.
 * `key_ring_location` - (Required) Location/region of the keyRing.
 * `key_ring_name` - (Required, modifiable) Key ring containing the keys to be used for volume encryption.
-* `network` - (Required) The path of the VPC the volumes are attached to, for example: "projects/my-host-project/global/networks/my-shared-vpc".
+* `network` - (Required) The path of the VPC the volumes are attached to, for example: "projects/12345678/global/networks/my-shared-vpc".
 
   
 ## Attributes Reference


### PR DESCRIPTION
This PR fixes #70.

It also fixes a confusion of "region" (the region the KMS config to create in) and "keyRingLocation" (the location of the key in KMS).
It also updates the documentation for the website.