### PR TITLE
Volume datasource update

### DIFF
--- a/gcp/resource_netapp_gcp_volume.go
+++ b/gcp/resource_netapp_gcp_volume.go
@@ -336,6 +336,11 @@ func resourceGCPVolume() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"security_style": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"ntfs", "unix"}, true),
+			},
 			"billing_label": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -458,6 +463,10 @@ func resourceGCPVolumeCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("unix_permissions"); ok {
 		volume.UnixPermissions = v.(string)
+	}
+
+	if v, ok := d.GetOk("security_style"); ok {
+		volume.SecurityStyle = v.(string)
 	}
 
 	volume.SnapshotDirectory = d.Get("snapshot_directory").(bool)
@@ -759,6 +768,11 @@ func resourceGCPVolumeRead(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Error reading volume unix_permissions: %s", err)
 		}
 	}
+	if _, ok := d.GetOk("security_style"); ok {
+		if err := d.Set("security_style", res.SecurityStyle); err != nil {
+			return fmt.Errorf("Error reading volume security_style: %s", err)
+		}
+	}
 	if _, ok := d.GetOk("billing_label"); ok {
 		labels := flattenBillingLabel(res.BillingLabels)
 		if err := d.Set("billing_label", labels); err != nil {
@@ -923,6 +937,11 @@ func resourceGCPVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("unix_permissions") {
 		makechange = 1
 		volume.UnixPermissions = d.Get("unix_permissions").(string)
+	}
+
+	if d.HasChange("security_style") {
+		makechange = 1
+		volume.SecurityStyle = d.Get("security_style").(string)
 	}
 
 	if d.HasChange("billing_label") {

--- a/gcp/volume.go
+++ b/gcp/volume.go
@@ -33,6 +33,7 @@ type volumeRequest struct {
 	RegionalHA             bool           `structs:"regionalHA,omitempty"`
 	SnapshotDirectory      bool           `structs:"snapshotDirectory"`
 	UnixPermissions        string         `structs:"unixPermissions,omitempty"`
+	SecurityStyle          string         `structs:"securityStyle,omitempty"`
 	SharedVpcProjectNumber string
 	SmbShareSettings       []string       `structs:"smbShareSettings,omitempty"`
 	BillingLabels          []billingLabel `structs:"billingLabels"`
@@ -61,6 +62,7 @@ type volumeResult struct {
 	SnapshotDirectory     bool           `json:"snapshotDirectory,omitempty"`
 	SmbShareSettings      []string       `json:"smbShareSettings,omitempty"`
 	UnixPermissions       string         `json:"unixPermissions,omitempty"`
+	SecurityStyle         string         `json:"securityStyle,omitempty"`
 	BillingLabels         []billingLabel `json:"billingLabels,omitempty"`
 }
 

--- a/website/docs/r/volume.html.markdown
+++ b/website/docs/r/volume.html.markdown
@@ -93,6 +93,7 @@ Service-Type CVS specific settings:
 
 Protocol settings:
 * `protocol_types` - (Required) The protocol_type of the volume. For CVS use 'NFSv3' or 'SMB'. For CVS-Performance use 'NFSv3', 'NFSv4' or 'SMB', or a combinations of ['NFSv3', 'NFSv4'], ['SMB', 'NFSv3'] and ['SMB', 'NFSv4'].
+* `security_style` - (Optional) Security style for dual-protocol volumes of protocol_type ['SMB', 'NFSv3'] or ['SMB', 'NFSv4']. Valid choices are 'unix' and 'ntfs'. Pure NFS volumes will always be unix, pure SMB volumes always be ntfs. Setting cannot be changed after volume creation.
 
 SMB protocol specific settings:
 * `smb_share_settings` - (Optional) List of SMB share properties. Must be zero or more of "encrypt_data", "browsable", "changenotify", "non_browsable", "oplocks", "showsnapshot", "show_previous_versions", "continuously_available", "access_based_enumeration".


### PR DESCRIPTION
Volume datasource is massively outdated. This PR brings it to the currently functionality level of volume resource.
Approach taken:
1. Copy Schema from volume resource
2. Change all "required" and "optional" field into "Computed" fields, except the input parameters region and name.
3. Remove all defaults in Schema
4. Use read operation from volume resource to read the volume and populate all the fields. That saves a lot of code repetition and eliminates a lot of code divergence.