### PR TITLE
Fix replication update

### DIFF
--- a/gcp/cvs/restapi/client.go
+++ b/gcp/cvs/restapi/client.go
@@ -25,6 +25,7 @@ func (c *Client) Do(baseURL string, req *Request) (int, []byte, error) {
 	if err != nil {
 		return 0, nil, err
 	}
+	log.Print("REQUEST: ", httpReq.Method, " ", httpReq.URL)
 	httpRes, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		log.Print("HTTP req failed")

--- a/gcp/resource_netapp_gcp_volume_replication.go
+++ b/gcp/resource_netapp_gcp_volume_replication.go
@@ -50,6 +50,7 @@ func resourceGCPVolumeReplication() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"MirrorAllSnapshots", "MirrorLatest", "MirrorAndVault"}, true),
+				Default:      "MirrorAllSnapshots",
 			},
 			"schedule": {
 				Type:         schema.TypeString,
@@ -197,6 +198,8 @@ func resourceGCPVolumeReplicationDelete(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
+	//TODO: Need to wait until replication is really deleted, otherwise follow on volume deletes might fail
+
 	return nil
 }
 
@@ -235,6 +238,7 @@ func resourceGCPVolumeReplicationUpdate(d *schema.ResourceData, meta interface{}
 	client := meta.(*Client)
 	replica := volumeReplicationRequest{}
 	replica.ReplicationID = d.Id()
+	replica.Region = d.Get("region").(string)
 
 	if d.HasChange("schedule") {
 		replica.Schedule = d.Get("schedule").(string)
@@ -256,5 +260,5 @@ func resourceGCPVolumeReplicationUpdate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	return resourceGCPVolumeRead(d, meta)
+	return resourceGCPVolumeReplicationRead(d, meta)
 }


### PR DESCRIPTION
Updating replications is broken in current provider. This fix make updates work.
- Make replication updates work
- Add default value for "policy" field to make execution plan stable

For better diagnostics (with TF_LOG=debug), it also changes:
- Print HTTP method and URL called to debug output for easier debugging
